### PR TITLE
Fix typo in render_file() use of @_

### DIFF
--- a/lib/Text/Caml.pm
+++ b/lib/Text/Caml.pm
@@ -48,7 +48,7 @@ sub render_file {
     my $context  = ref $_[0] eq 'HASH' ? $_[0] : {@_};
 
     $template = $self->_slurp_template($template);
-    return $self->_parse($template, @_);
+    return $self->_parse($template, $context);
 }
 
 sub _parse {

--- a/lib/Text/Caml.pm
+++ b/lib/Text/Caml.pm
@@ -54,7 +54,7 @@ sub render_file {
 sub _parse {
     my $self     = shift;
     my $template = shift;
-    my $context  = ref $_[0] eq 'HASH' ? $_[0] : {@_};
+    my $context  = shift;
 
     my $output = '';
 

--- a/t/regressions.t
+++ b/t/regressions.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More tests => 1;
+
+use Text::Caml;
+
+use File::Basename ();
+use File::Spec ();
+
+# Had '@_' instead of 'ref $_[0] eq 'HASH' ? $_[0] : {@_}' in render_file.
+# Without this test no tests actually caught that bug.
+{
+    my $renderer = Text::Caml->new;
+
+    my $templates_path = File::Spec->catfile(
+        File::Basename::dirname(__FILE__), 'templates'
+    );
+
+    my $output = $renderer->render_file(
+        File::Spec->catfile($templates_path, 'partial-with-directives'),
+        name => "Alex",
+    );
+
+    is(
+        $output,
+        'Hello Alex!',
+        'handle non-hashref context in render_file()'
+    );
+}


### PR DESCRIPTION
The logic for correctly handling hashref contexts which is used in render() was not correctly being used in render_file().

None of the tests fail before or after this change. Lame. If I were a better person I would have written a failing test for you... :-)