### PR TITLE
Added hash keys support (not fully tested)

### DIFF
--- a/lib/Text/Caml.pm
+++ b/lib/Text/Caml.pm
@@ -7,7 +7,7 @@ require Carp;
 require Scalar::Util;
 use File::Spec ();
 
-our $VERSION = '0.11';
+our $VERSION = '0.12';
 
 our $LEADING_SPACE  = qr/(?:\n [ ]*)?/x;
 our $TRAILING_SPACE = qr/(?:[ ]* \n)?/x;
@@ -18,6 +18,8 @@ our $START_OF_PARTIAL          = quotemeta '>';
 our $START_OF_SECTION          = quotemeta '#';
 our $START_OF_INVERTED_SECTION = quotemeta '^';
 our $END_OF_SECTION            = quotemeta '/';
+
+our $HASH_KEYS                 = quotemeta '.keys';
 
 sub new {
     my $class = shift;
@@ -254,12 +256,20 @@ sub _parse_section {
     my $self = shift;
     my ($name, $template, $context) = @_;
 
+    my $get_keys = ($name =~ s/$HASH_KEYS$//g)? 1 : 0;
     my $value = $self->_get_value($context, $name);
 
     my $output = '';
 
     if (ref $value eq 'HASH') {
-        $output .= $self->_parse($template, {%$context, %$value});
+        if($get_keys eq 1) {
+            foreach my $el (keys %$value) {
+                $value->{$el}{'.'} = $el;
+                $output .= $self->_parse($template, $value->{$el});
+            }
+        } else {
+            $output .= $self->_parse($template, {%$context, %$value});
+        }
     }
     elsif (ref $value eq 'ARRAY') {
         my $idx = 0;
@@ -492,6 +502,22 @@ elements.
     {{/hash}}
 
     123
+
+
+=item *
+
+Hash keys, C<hash_keys> is a non-empty hash reference. Context is swithed to the
+elements.
+
+    # hash => {one => {val => 1}, two => {val => 2}, three => {val => 3}}
+    {{#hash.keys}}
+    {{.}} = {{val}}
+
+    {{/hash.keys}}
+
+    one = 1
+    two = 2
+    three = 3
 
 =item *
 

--- a/t/hash_keys.t
+++ b/t/hash_keys.t
@@ -1,0 +1,34 @@
+use strict;
+use warnings;
+
+package Foo;
+
+sub new {
+    shift;
+    bless {@_};
+}
+
+sub method { shift->{values} }
+
+package main;
+
+use Test::More;
+
+use Text::Caml;
+
+my $renderer = Text::Caml->new;
+my $output;
+
+$output = $renderer->render(do {local $/; <DATA>}, {
+    h => {
+        foo => { a => 42, b => 43, },
+        bar => { a => 52, b => 53, }}});
+
+is $output => 'bar5253foo4243', 'iteration over hash keys';
+
+done_testing;
+
+__DATA__
+{{#h.keys}}
+{{.}}{{a}}{{b}}
+{{/h.keys}}


### PR DESCRIPTION
As mentionned on the issue I reported today. I suggest implementing `hash.keys` support. This is currently more a hack than a full new feature implementation, but I think you got the idea. 

What is possible now,  is to iterate trough an hash. The current key is available with `{{.}}` and the internal keys values can be accessed by their name:

    {{#hash.keys}}
        {{.}} {{name}} {{genre}}
    {{/hash.keys}}

