### PR TITLE
lazy Carp loading

### DIFF
--- a/lib/Text/Caml.pm
+++ b/lib/Text/Caml.pm
@@ -3,7 +3,6 @@ package Text::Caml;
 use strict;
 use warnings;
 
-require Carp;
 require Scalar::Util;
 use File::Spec ();
 
@@ -18,6 +17,8 @@ our $START_OF_PARTIAL          = quotemeta '>';
 our $START_OF_SECTION          = quotemeta '#';
 our $START_OF_INVERTED_SECTION = quotemeta '^';
 our $END_OF_SECTION            = quotemeta '/';
+
+sub croak {require Carp; goto &Carp::croak}
 
 sub new {
     my $class = shift;
@@ -98,7 +99,7 @@ sub _parse {
                     $chunk .= $self->_parse_section($name, $1, $context);
                 }
                 else {
-                    Carp::croak("Section's '$name' end not found");
+                    croak("Section's '$name' end not found");
                 }
             }
 
@@ -117,13 +118,13 @@ sub _parse {
                       .= $self->_parse_inverted_section($name, $1, $context);
                 }
                 else {
-                    Carp::croak("Section's '$name' end not found");
+                    croak("Section's '$name' end not found");
                 }
             }
 
             # End of section
             elsif ($template =~ m/\G $END_OF_SECTION (.*?) $END_TAG/gcxms) {
-                Carp::croak("Unexpected end of section '$1'");
+                croak("Unexpected end of section '$1'");
             }
 
             # Partial
@@ -136,7 +137,7 @@ sub _parse {
                 $chunk .= $self->_parse_tag_escaped($1, $context);
             }
             else {
-                Carp::croak("Can't find where tag is closed");
+                croak("Can't find where tag is closed");
             }
 
             if ($chunk ne '') {
@@ -345,7 +346,7 @@ sub _slurp_template {
       ? File::Spec->catfile($self->templates_path, $template)
       : $template;
 
-    Carp::croak("Can't find '$path'") unless defined $path && -f $path;
+    croak("Can't find '$path'") unless defined $path && -f $path;
 
     my $content = do {
         local $/;
@@ -353,7 +354,7 @@ sub _slurp_template {
         <$file>;
     };
 
-    Carp::croak("Can't open '$template'") unless defined $content;
+    croak("Can't open '$template'") unless defined $content;
 
     chomp $content;
 

--- a/lib/Text/Caml.pm
+++ b/lib/Text/Caml.pm
@@ -18,8 +18,6 @@ our $START_OF_SECTION          = quotemeta '#';
 our $START_OF_INVERTED_SECTION = quotemeta '^';
 our $END_OF_SECTION            = quotemeta '/';
 
-sub croak {require Carp; goto &Carp::croak}
-
 sub new {
     my $class = shift;
     my (%params) = @_;
@@ -99,7 +97,7 @@ sub _parse {
                     $chunk .= $self->_parse_section($name, $1, $context);
                 }
                 else {
-                    croak("Section's '$name' end not found");
+                    _croak("Section's '$name' end not found");
                 }
             }
 
@@ -118,13 +116,13 @@ sub _parse {
                       .= $self->_parse_inverted_section($name, $1, $context);
                 }
                 else {
-                    croak("Section's '$name' end not found");
+                    _croak("Section's '$name' end not found");
                 }
             }
 
             # End of section
             elsif ($template =~ m/\G $END_OF_SECTION (.*?) $END_TAG/gcxms) {
-                croak("Unexpected end of section '$1'");
+                _croak("Unexpected end of section '$1'");
             }
 
             # Partial
@@ -137,7 +135,7 @@ sub _parse {
                 $chunk .= $self->_parse_tag_escaped($1, $context);
             }
             else {
-                croak("Can't find where tag is closed");
+                _croak("Can't find where tag is closed");
             }
 
             if ($chunk ne '') {
@@ -346,7 +344,7 @@ sub _slurp_template {
       ? File::Spec->catfile($self->templates_path, $template)
       : $template;
 
-    croak("Can't find '$path'") unless defined $path && -f $path;
+    _croak("Can't find '$path'") unless defined $path && -f $path;
 
     my $content = do {
         local $/;
@@ -354,7 +352,7 @@ sub _slurp_template {
         <$file>;
     };
 
-    croak("Can't open '$template'") unless defined $content;
+    _croak("Can't open '$template'") unless defined $content;
 
     chomp $content;
 
@@ -392,6 +390,8 @@ sub _escape {
 
     return $value;
 }
+
+sub _croak {require Carp; goto &Carp::croak}
 
 1;
 __END__


### PR DESCRIPTION
From Carp package is used only croak function to die,
not for normal work.

test \#4 in t/file.t

All test PASS.