### PR TITLE
add support for nested templates

### DIFF
--- a/lib/Text/Caml.pm
+++ b/lib/Text/Caml.pm
@@ -149,7 +149,7 @@ sub _parse {
                     $chunk .= $self->_parse_inherited_template($name, $1, $context);
                 }
                 else {
-                    Carp::croak("Section's '$name' end not found");
+                    Carp::croak("Nested template's '$name' end not found");
                 }
             }
 
@@ -165,7 +165,7 @@ sub _parse {
                     $chunk .= $self->_parse_block($name, $1, $context, $override);
                 }
                 else {
-                    Carp::croak("Section's '$name' end not found");
+                    Carp::croak("Block's '$name' end not found");
                 }
             }
 
@@ -392,7 +392,19 @@ sub _parse_block {
 
     # get block content from override
     my $content;
-    if ($override =~ m/ $START_OF_BLOCK \s* $name \s* $END_TAG (.*) $START_TAG $END_OF_BLOCK \s* $name \s* $END_TAG/gxms) {
+    # first, see if we can find any starting block with this name
+    if ($override =~ m/ $START_OF_BLOCK \s* $name \s* $END_TAG/gcxms) {
+        # get the content of the block
+        if ($override =~ m/ (.*) $START_TAG $END_OF_BLOCK \s* $name \s* $END_TAG/gcxms){
+            my $content = $1;
+            return $self->_parse($content, $context);
+        } else {
+            
+        }
+               
+    }
+    
+    if ($override =~ m/ $START_OF_BLOCK \s* $name \s* $END_TAG (.*) $START_TAG $END_OF_BLOCK \s* $name \s* $END_TAG/gcxms) {
         my $content = $1;
         return $self->_parse($content, $context);
     }

--- a/lib/Text/Caml.pm
+++ b/lib/Text/Caml.pm
@@ -392,23 +392,18 @@ sub _parse_block {
 
     # get block content from override
     my $content;
-    # first, see if we can find any starting block with this name
+   
+    # first, see if we can find any starting block with this name in the override
     if ($override =~ m/ $START_OF_BLOCK \s* $name \s* $END_TAG/gcxms) {
-        # get the content of the block
+        # get the content of the override block and make sure there's a corresponding end-block tag for it!
         if ($override =~ m/ (.*) $START_TAG $END_OF_BLOCK \s* $name \s* $END_TAG/gcxms){
             my $content = $1;
             return $self->_parse($content, $context);
         } else {
-            
-        }
-               
+            Carp::croak("Block's '$name' end not found");
+        }               
     }
-    
-    if ($override =~ m/ $START_OF_BLOCK \s* $name \s* $END_TAG (.*) $START_TAG $END_OF_BLOCK \s* $name \s* $END_TAG/gcxms) {
-        my $content = $1;
-        return $self->_parse($content, $context);
-    }
-
+   
     return $self->_parse($template, $context);
 }
 

--- a/t/template-inheritance.t
+++ b/t/template-inheritance.t
@@ -1,0 +1,30 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+use Text::Caml;
+
+my $renderer = Text::Caml->new(templates_path => 't/templates');
+
+# testing scenario where we provide the replacement content for a block
+my $output = $renderer->render('{{<inheritance}}{{$block}}Replaced Value!{{/block}}{{/inheritance}}');
+is $output => 'Replaced Value!', 'basic inheritance works correctly';
+
+# testing the scenario where no replacement is provided for a block and must use the default value
+$output = $renderer->render('{{<inheritance}}{{/inheritance}}');
+is $output => 'Default Value!', 'basic inheritance uses default values if no custom one provided for blocks';
+
+# testing directive use in replacement block
+$output = $renderer->render('{{<inheritance}}{{$block}}Hello {{name}}!{{/block}}{{/inheritance}}', {name => 'boss'});
+is $output => 'Hello boss!', 'directives work ok in replacement blocks';
+
+# testing directive use in default block values
+$output = $renderer->render('{{<inheritance-with-directives}}{{/inheritance-with-directives}}', {value => 'default'});
+is $output => 'This is a default value', 'directives work ok in default block values';
+
+# testing a more complex scenario with multiple levels of inheritance
+$output = $renderer->render('{{<inheritance-with-recursion}}{{/inheritance-with-recursion}}');
+is $output => 'I\'m recursive', 'recursive inheritance works ok';
+
+done_testing;

--- a/t/templates/inheritance
+++ b/t/templates/inheritance
@@ -1,0 +1,1 @@
+{{$block}}Default Value!{{/block}}

--- a/t/templates/inheritance-with-directives
+++ b/t/templates/inheritance-with-directives
@@ -1,0 +1,1 @@
+{{$block}}This is a {{value}} value{{/block}}

--- a/t/templates/inheritance-with-recursion
+++ b/t/templates/inheritance-with-recursion
@@ -1,0 +1,1 @@
+{{<inheritance}}{{$block}}I'm recursive{{/block}}{{/inheritance}}


### PR DESCRIPTION
Added template inheritance (nested templates) support as described here: https://github.com/mustache/spec/pull/75

```html
{{! header.mustache }}
<head>
  <title>{{$title}}Default title{{/title}}</title>
</head>

{{! base.mustache }}
<html>
  {{$header}}{{/header}}
  {{$content}}{{/content}}
</html>

{{! mypage.mustache }}
{{<base}}
  {{$header}}
    {{<header}}
      {{$title}}My page title{{/title}}
    {{/header}}
  {{/header}}

  {{$content}}
    <h1>Hello world</h1>
  {{/content}}
{{/base}}
```
Rendering mypage.mustache would output:
```html
<html><head><title>My page title</title></head><h1>Hello world</h1></html>
```