### PR TITLE
Implement the same behavior as in JS Mustache version for indexing arrays

### DIFF
--- a/lib/Text/Caml.pm
+++ b/lib/Text/Caml.pm
@@ -238,13 +238,19 @@ sub _find_value {
     my $value = $context;
 
     foreach my $part (@parts) {
-        if (   exists $value->{'_with'}
+        if ( ref $value eq "HASH"
+            && exists $value->{'_with'}
             && Scalar::Util::blessed($value->{'_with'})
             && $value->{'_with'}->can($part))
         {
             $value = $value->{'_with'}->$part;
             next;
         }
+
+	if( ref $value eq "ARRAY" ) {
+		$value = $value->[$part];
+		next;
+	}
 
         if (   exists $value->{'.'}
             && Scalar::Util::blessed($value->{'.'})

--- a/t/variables.t
+++ b/t/variables.t
@@ -11,7 +11,7 @@ sub method { shift->{bar} }
 
 package main;
 
-use Test::More tests => 16;
+use Test::More tests => 18;
 
 use Text::Caml;
 
@@ -64,3 +64,9 @@ is $output => '', '{{foo.bak}} non-existent hashref foo renders as empty string'
 
 $output = $renderer->render('{{foo.method}}', {foo => Foo->new(bar => 'baz')});
 is $output => 'baz', '{{foo.method}} object method call renders as return value of method';
+
+$output = $renderer->render('{{foo.0}}', {foo => [qw/bar baz/]});
+is $output => 'bar', 'get index of a array';
+
+$output = $renderer->render('{{{foo.1.text}}}', {foo => [{text => "bar"}, {text => "baz"}]});
+is $output => 'baz', 'get a has as a index of a array';


### PR DESCRIPTION
Make it possible to do (as in JS):
```perl
$template->render("Position 0 of array: {{array.0}}", {array => ["data"]})
```