### PR TITLE
escape "{" and "}"

### DIFF
--- a/lib/Text/Caml.pm
+++ b/lib/Text/Caml.pm
@@ -75,7 +75,7 @@ sub _parse {
             my $leading_newline = !!$1;
 
             # Tripple
-            if ($template =~ m/\G { (.*?) } $END_TAG/gcxms) {
+            if ($template =~ m/\G \{ (.*?) \} $END_TAG/gcxms) {
                 $chunk .= $self->_parse_tag($1, $context);
             }
 


### PR DESCRIPTION
Unescaped left brace in regex is deprecated.
```
❯ perl -Ilib -MText::Caml -e 'Text::Caml->new->render("{{{}}}")'
Unescaped left brace in regex is deprecated here (and will be fatal in Perl 5.30), passed through in regex; marked by <-- HERE in m/\G { <-- HERE  (.*?) } (?^x:\}\})/ at lib/Text/Caml.pm line 78.
```
https://metacpan.org/pod/distribution/perl/pod/perl5220delta.pod#A-literal-"{"-should-now-be-escaped-in-a-pattern

This PR escapes `{` (and `}` with consistency).